### PR TITLE
Fix bug where dropped items shouldn't be respawned.

### DIFF
--- a/src/server/weapons.qc
+++ b/src/server/weapons.qc
@@ -263,7 +263,9 @@ Weapon_DropCurrentWeapon(base_player pl)
 	if (g_weapons[pl.activeweapon].allow_drop != TRUE)
 		return;
 
-	item_pickup drop = spawn(item_pickup, m_iWasDropped: TRUE, m_iClip: pl.a_ammo1);
+	item_pickup drop = spawn(item_pickup);
+	drop.m_iWasDropped = TRUE;
+	drop.m_iClip = pl.a_ammo1;
 	drop.SetItem(pl.activeweapon);
 	setorigin(drop, pl.origin);
 	drop.solid = SOLID_NOT;


### PR DESCRIPTION
Hi!

`spawn()` will cast it's params to floats (right?), so when `m_iWasDropped: TRUE` was given it would set `m_iWasDropped` to `1065353216`; and conditions like `m_iWasDropped == TRUE` where never met. Which would cause `valve/src/server/items.qc:item_pickup::touch` to set `think` to `Respawn`.

BTW: Great work on Nuclide et all!  :-D