### PR TITLE
Fix `Weapons_IsEmpty`

### DIFF
--- a/base/src/shared/weapon_common.qc
+++ b/base/src/shared/weapon_common.qc
@@ -254,14 +254,13 @@ Weapons_PreDraw(int thirdperson)
 int
 Weapons_IsEmpty(player pl, int w)
 {
-	int i = pl.activeweapon;
 	int r = 0;
 
 	entity oself = self;
 	self = pl;
 
-	if (g_weapons[i].isempty != __NULL__)
-		r = g_weapons[i].isempty();
+	if (g_weapons[w].isempty != __NULL__)
+		r = g_weapons[w].isempty();
 
 	self = oself;
 


### PR DESCRIPTION
I've noticed that FreeCS bots didn't switch to knife when they where out of
ammo, after investigating I found that the `int w` argument of
`Weapons_IsEmpty` was ignored and instead the `activeweapon` of the player was
used. So when `Weapons_SwitchBest` checks if the knife is empty it would return
`TRUE` because it wasn't really checking on the knife but on the player it's
`activeweapon`.

I think it is leftover from testing/debugging? (https://github.com/VeraVisions/nuclide/commit/c5cea7a1620a00aed0a87c0854da5cde441d0cc6)