### PR TITLE
build_editor.sh: Error out if no build result to copy

### DIFF
--- a/build_editor.sh
+++ b/build_editor.sh
@@ -6,6 +6,9 @@ mv_wsfile()
 	if [ -f "./build/$1" ]
 	then
 		cp -v "./build/$1" "../../bin/$1"
+	else
+		printf "'%s' file not found!\n" "$1"
+		exit
 	fi
 }
 
@@ -14,6 +17,9 @@ mv_msysfile()
 	if [ -f "./build/$1" ]
 	then
 		cp -v "./build/$1" "../../bin/$1"
+	else
+		printf "'%s' file not found!\n" "$1"
+		exit
 	fi
 }
 


### PR DESCRIPTION
Prevents silently ignoring missing files used with `mv_wsfile`/`mv_msysfile`.

Sidenote: [platform.game/platform/entities.def](https://github.com/VeraVisions/nuclide/blob/1b24b30cdb7614fa91ea68b9a45a381d98044fcd/build_editor.sh#L243) doesn't seem to exist, should it?

Sidenote 2: `mv_msysfile` is not used anywhere.