### PR TITLE
fixed being able to do elevator boosts/jumps in corners, and getting …

### DIFF
--- a/src/shared/physics/player_pmove.qc
+++ b/src/shared/physics/player_pmove.qc
@@ -300,9 +300,8 @@ ncPlayer::Physics_CheckJump(float premove)
 			return;
 
 	if (input_buttons & INPUT_JUMP && premove) {
-		if (velocity[2] < 0) {
-			velocity[2] = 0;
-		}
+		 /* always zero out gravity to prevent elevators / jump boost in corners */
+		velocity[2] = 0;
 
 		Physics_Jump();
 		RemoveFlags(FL_ONGROUND);
@@ -603,6 +602,7 @@ ncPlayer::Physics_Run(void)
 {
 	float flFallVel = (flags & FL_ONGROUND) ? 0 : -velocity[2];
 	float flBaseVel =  m_pmoveBaseVelocity[2];
+	float maxFall = 1024.0f;
 	bool wasOnGround = (flags & FL_ONGROUND) ? true : false;
 	bool sprintFail = false;
 
@@ -656,10 +656,16 @@ ncPlayer::Physics_Run(void)
 
 	Physics_CheckJump(FALSE);
 
+	 /* prevents gravity from building up to lethal damage when stuck in corner */
+	if (!(flags & FL_ONGROUND) && velocity[2] < -maxFall)
+		velocity[2] = -maxFall;
+
 	if (wasOnGround == false && (flags & FL_ONGROUND)) {
 		if (waterlevel != 0) {
 			flFallVel = 0;
 		}
+		/* cap velocity for current landing */
+		flFallVel = min(flFallVel, maxFall);
 		Physics_Fall(flFallVel - flBaseVel);
 	}
 

--- a/src/shared/physics/pmove_custom.qc
+++ b/src/shared/physics/pmove_custom.qc
@@ -491,8 +491,7 @@ PMoveCustom_Fix_Origin(void)
 		}
 	}
 
-#if 0
-	/* still not done */
+	/* nudge out of corners */
 	for (z = 0; z < 3; z++) {
 		norg = oorg;
 		norg[z] = oorg[z] + 0.25;
@@ -501,7 +500,7 @@ PMoveCustom_Fix_Origin(void)
 			self.origin = norg;
 			return (1);
 		}
-		
+
 		norg = oorg;
 		norg[z] = oorg[z] - 0.25;
 		tracebox(norg, self.mins, self.maxs, norg, MOVE_NORMAL, self);
@@ -510,18 +509,6 @@ PMoveCustom_Fix_Origin(void)
 			return (1);
 		}
 	}
-
-	for (z = 0; z < 64; z++) {
-		norg = oorg;
-		norg[2] += z * 0.125;
-		tracebox(norg, self.mins, self.maxs, norg, MOVE_NORMAL, self);
-		if (!trace_startsolid) {
-			tracebox(norg, self.mins, self.maxs, norg + [0,0,18], MOVE_NORMAL, self);
-			self.origin = norg;
-			return (1);
-		}
-	}
-#endif
 
 	return (0);
 }
@@ -535,6 +522,8 @@ PMoveCustom_Move(void)
 	float stepped;
 	float move_time;
 	float i;
+	/* get the Z before move so we can detect if stuck in a corner. */
+	float startZ = self.origin[2];
 
 	/* noclippers don't need any of the below since they don't collide with anything */
 	if (self.movetype == MOVETYPE_NOCLIP) {
@@ -553,6 +542,8 @@ PMoveCustom_Move(void)
 
 		if (trace_startsolid) {
 			if (!PMoveCustom_Fix_Origin()) {
+				/* Completely stuck */
+				self.velocity[2] = 0;
 				return;
 			}
 			continue;
@@ -657,6 +648,15 @@ PMoveCustom_Move(void)
 		}*/
 		PMoveCustom_DoTouch(trace_ent);
 		self.groundentity = trace_ent;
+	}
+
+	 /* corner death protection: checks if we are wedged between walls so gravity doesnt accumulate */
+	if (!(self.flags & FL_ONGROUND) && self.velocity[2] < -100.0f) {
+		float movedZ    = startZ - self.origin[2];
+		float expectedZ = -self.velocity[2] * input_timelength;
+		if (movedZ < expectedZ * 0.1f) {
+			self.velocity[2] = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
…stuck in corners and dying from velocity.

Fixes: 

-If you go into a gapped corner (ie 2 bsp hulls almost touching eachother in a corner but still has a gap between them), walking into it, and spamming jump. When you let go of move, it will launch/elevator boost you very high in the air. Fixed.

-When jumping into a gapped corner you would get stuck, and gravity would increase to a lethal amount, once letting go you would launch into ground dying from impact. Fixed.